### PR TITLE
Add UpdateTodo endpoint to TodosController

### DIFF
--- a/CI_CD_TEST/Controllers/TodosController.cs
+++ b/CI_CD_TEST/Controllers/TodosController.cs
@@ -36,6 +36,24 @@ namespace CI_CD_TEST.Controllers
             _context.Todo.Add(todo);
             _context.SaveChanges();
             return CreatedAtAction(nameof(GetTodos), new { id = todo.Id }, todo);
-        }            
+        }
+
+        [HttpPut]
+        public ActionResult<Todo> UpdateTodo([FromBody] Todo updatedTodo)
+        {
+            var updatedEntity = _context.Todo.FirstOrDefault(x => x.Id == updatedTodo.Id);
+            if (updatedEntity == null)
+            {
+                return NotFound($"Todo with ID {updatedTodo.Id} not found.");
+            }
+
+            updatedEntity.Name = updatedTodo.Name;
+            updatedEntity.IsComplete = updatedTodo.IsComplete;
+
+            _context.Todo.Update(updatedEntity);
+            _context.SaveChanges();
+
+            return Ok(updatedEntity);
+        }
     }
 }


### PR DESCRIPTION
Added an HTTP PUT endpoint `UpdateTodo` in `TodosController` to update existing `Todo` entities. The method retrieves a `Todo` by `Id`, updates its `Name` and `IsComplete` properties, and saves changes to the database. Returns `NotFound` if the entity is missing or `Ok` with the updated entity on success.